### PR TITLE
Updated post_peek's strokes in svgs message

### DIFF
--- a/.github/scripts/icomoon_peek.py
+++ b/.github/scripts/icomoon_peek.py
@@ -20,9 +20,9 @@ def main():
         messages = runner.peek(svgs, screenshot_folder)
         print("Task completed.")
 
-        message = "**No strokes detected in SVGs.**"
+        message = ""
         if messages != []:
-            message = "**Strokes detected in SVGs:**\n" + "\n\n".join(messages)
+            message = "\n**Strokes detected in SVGs:**\n" + "\n\n".join(messages) + "\n"
         filehandler.write_to_file("./err_messages.txt", message)
     except Exception as e:
         filehandler.write_to_file("./err_messages.txt", str(e))

--- a/.github/workflows/post_peek_screenshot.yml
+++ b/.github/workflows/post_peek_screenshot.yml
@@ -97,9 +97,7 @@ jobs:
             1. The number of Glyphs matches the number of SVGs that were selected. 
             2. The icons (second group of pictures) look the same as the SVGs (first group of pictures). 
             3. The icons are of high quality (legible, matches the official logo, etc.)
-
             {4}
-
             In case of font issues, it might be caused by Icomoon not acceptin strokes in the SVGs. 
             Check this [doc](https://icomoon.io/#faq/importing) for more details and fix the issues as 
             instructed by Icomoon and update this PR once you are done.


### PR DESCRIPTION
---
name: Pull Request Template
about: Add a new icon or feature to the repo.
title: 'New Icon/Feature: [NAME]'
assignees: ''

---
# New Icon Section

<!-- If you are adding a new icon, follow the steps listed here, and delete the **New Feature** section below. -->

## Double check these details before you open a PR

<!-- Tick the checkboxes to ensure you've done everything correctly -->
- [] PR does not match another non-stale PR currently opened
- [] PR name matches the format *new icon: <i>Icon name</i> (<i>versions separated by comma</i>)*. More details [here](https://github.com/devicons/devicon/blob/develop/CONTRIBUTING.md#overview)
- [] PR's base is the `develop` branch.
- [] Your icons are inside a folder as seen [here](https://github.com/devicons/devicon/blob/develop/CONTRIBUTING.md#organizational-guidelines)
- [] SVG matches the standards laid out [here](https://github.com/devicons/devicon/blob/develop/CONTRIBUTING.md#svgStandards)
- [] A new object is added in the `devicon.json` file as seen [here](https://github.com/devicons/devicon/blob/develop/CONTRIBUTING.md#-updating-the-deviconjson-)

<!-- Refer to the [contributing](https://github.com/devicons/devicon/blob/develop/CONTRIBUTING.md#contributing-to-devicon) guidelines for more details. -->

## Link to prove your SVG is correct and up-to-date.
<!-- Link to an official page/wiki goes here. Anything that proves your SVGs are the correct ones. -->

---
# New Feature Section

<!-- If you are adding a new icon, follow the steps listed here, and delete the **New Icon** section above. -->

## Double check these details before you open a PR**

<!-- Tick the checkboxes to ensure you've done everything correctly -->
- [] PR does not match another non-stale PR currently opened
- [] PR name matches the format *New Feature: brief description of feature*


## This PR adds/fixes...

<!-- List your features here and the benefits they bring. -->

## Notes

<!-- List anything note-worthy here (potential issues, this needs to be merged to `master` before working, etc.). -->
